### PR TITLE
rename jobs output file from epm.json to jobs_output.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ docs/eris-cli
 builds
 epm.csv
 epm.log
-epm.json
+jobs_output.json
 tests/fixtures/*/abi
 docs/eris-pm
 tests/fixtures/chaindata/genesis.json

--- a/perform/job_manager.go
+++ b/perform/job_manager.go
@@ -172,7 +172,7 @@ func postProcess(do *definitions.Do) error {
 			}
 		}
 	case "json":
-		log.Info("Writing [epm.json] to current directory")
+		log.Info("Writing [jobs_output.json] to current directory")
 		results := make(map[string]string)
 		for _, job := range do.Package.Jobs {
 			results[job.JobName] = job.JobResult

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -148,7 +148,7 @@ run_test(){
 
   rm -rf ./abi &>/dev/null
   rm *.bin &>/dev/null
-  rm ./epm.json &>/dev/null
+  rm ./jobs_output.json &>/dev/null
   rm ./epm.csv &>/dev/null
 
   # Reset for next run

--- a/util/writers.go
+++ b/util/writers.go
@@ -15,7 +15,7 @@ import (
 )
 
 const LogFileNameCSV = "epm.csv"
-const LogFileNameJSON = "epm.json"
+const LogFileNameJSON = "jobs_output.json"
 
 // ------------------------------------------------------------------------
 // Logging


### PR DESCRIPTION
- closes #176 
- properly describes the output fileName