### PR TITLE
update use of [chains new --dir] => [chains start --init-dir]

### DIFF
--- a/tests/test.sh
+++ b/tests/test.sh
@@ -117,7 +117,7 @@ test_setup(){
   key2_pub=$(cat $chain_dir/accounts.csv | grep $name_part | cut -d ',' -f 1)
   echo -e "Default Key =>\t\t\t\t$key1_addr"
   echo -e "Backup Key =>\t\t\t\t$key2_addr"
-  eris chains new $chain_name --dir $chain_dir/$name_full 1>/dev/null
+  eris chains start $chain_name --init-dir $chain_dir/$name_full 1>/dev/null
   sleep 5 # boot time
   echo "Setup complete"
 }

--- a/tests/test_stacktests_jenkins.sh
+++ b/tests/test_stacktests_jenkins.sh
@@ -83,7 +83,7 @@ tests_setup() {
   echo -e "Backup Key =>\t\t\t\t$key2_addr"
 
   # boot the chain
-  eris chains new $chain_name --dir $chain_dir/$name_full 1>/dev/null
+  eris chains start $chain_name --init-dir $chain_dir/$name_full 1>/dev/null
   if [ $? -ne 0 ]; then return 1; fi
   sleep 5 # boot time
   echo "Tests Setup complete"


### PR DESCRIPTION
- required for https://github.com/eris-ltd/eris-cli/pull/932
- since [chains new] is being kept as a deprecated command, tests should be triggered once 932 is merged and pass before merging this PR
