### PR TITLE
Update develop version.go

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // This line needs to be last
-const VERSION = "0.12.0-rc3"
+const VERSION = "0.12.0-develop"


### PR DESCRIPTION
Suffix develop branch version with '-develop' to avoid pushing to 0.12.0 tag on quay before release.