### PR TITLE
issue1082 silence abi output from compilers; hotfix on 0.12.1

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -21,7 +21,7 @@ imports:
   - go/common
   - go/docs
 - name: github.com/eris-ltd/eris-compilers
-  version: d3c710fb329cd0fbff47fe8e83deb04040a78b8f
+  version: f3a46af81bca5cb05d8b389b6383a498b8fcf831
   subpackages:
   - network
   - util

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // This line needs to be last
-const VERSION = "0.12.0"
+const VERSION = "0.12.1"


### PR DESCRIPTION
fixes https://github.com/eris-ltd/eris-cli/issues/1082 on 0.12.1 for eris-pm
